### PR TITLE
Adding logparser to build models

### DIFF
--- a/spackmon/apps/main/logparser.py
+++ b/spackmon/apps/main/logparser.py
@@ -1,0 +1,532 @@
+# -----------------------------------------------------------------------------
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2017 Kitware, Inc. and Contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Kitware, Inc. nor the names of Contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# -----------------------------------------------------------------------------
+#
+# The above copyright and license notice applies to distributions of
+# CMake in source and binary form.  Third-party software packages supplied
+# with CMake under compatible licenses provide their own copyright notices
+# documented in corresponding subdirectories or source files.
+#
+# -----------------------------------------------------------------------------
+#
+# CMake was initially developed by Kitware with the following sponsorship:
+#
+#  * National Library of Medicine at the National Institutes of Health
+#    as part of the Insight Segmentation and Registration Toolkit (ITK).
+#
+#  * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+#    Visualization Initiative.
+#
+#  * National Alliance for Medical Image Computing (NAMIC) is funded by the
+#    National Institutes of Health through the NIH Roadmap for Medical
+#    Research, Grant U54 EB005149.
+#
+#  * Kitware, Inc.
+# -----------------------------------------------------------------------------
+"""Functions to parse build logs and extract error messages.
+
+This is a python port of the regular expressions CTest uses to parse log
+files here:
+
+    https://github.com/Kitware/CMake/blob/master/Source/CTest/cmCTestBuildHandler.cxx
+
+This file takes the regexes verbatim from there and adds some parsing
+algorithms that duplicate the way CTest scrapes log files.  To keep this
+up to date with CTest, just make sure the ``*_matches`` and
+``*_exceptions`` lists are kept up to date with CTest's build handler.
+"""
+from __future__ import print_function
+from __future__ import division
+
+import re
+import math
+import multiprocessing
+import time
+from spackmon.apps.main.models import BuildWarning as BW, BuildError as BE
+from contextlib import contextmanager
+
+from six import StringIO
+from six import string_types
+
+
+def parse_build_logs(build):
+    """
+    Given a build, generate log objects for it
+    """
+    parser = CTestLogParser()
+
+    for phase in build.buildphase_set.all():
+        for output in [phase.output, phase.error]:
+            if not output:
+                continue
+            errors, warnings = parser.parse(output)
+
+            # Create errors and warning objects
+            for warning in warnings:
+                log = BW.objects.create(
+                    phase=phase,
+                    source_file=warning.source_file,
+                    source_line_no=warning.source_line_no,
+                    line_no=warning.line_no,
+                    repeat_count=warning.repeat_count,
+                    start=warning.start,
+                    end=warning.end,
+                    text=warning.text,
+                    pre_context="\n".join(warning.pre_context),
+                    post_context="\n".join(warning.post_context),
+                )
+            for error in errors:
+                log = BE.objects.create(
+                    phase=phase,
+                    source_file=warning.source_file,
+                    source_line_no=warning.source_line_no,
+                    line_no=warning.line_no,
+                    repeat_count=warning.repeat_count,
+                    start=warning.start,
+                    end=warning.end,
+                    text=warning.text,
+                    pre_context="\n".join(warning.pre_context),
+                    post_context="\n".join(warning.post_context),
+                )
+
+
+class prefilter(object):
+    """Make regular expressions faster with a simple prefiltering predicate.
+
+    Some regular expressions seem to be much more costly than others.  In
+    most cases, we can evaluate a simple precondition, e.g.::
+
+        lambda x: "error" in x
+
+    to avoid evaluating expensive regexes on all lines in a file. This
+    can reduce parse time for large files by orders of magnitude when
+    evaluating lots of expressions.
+
+    A ``prefilter`` object is designed to act like a regex,, but
+    ``search`` and ``match`` check the precondition before bothering to
+    evaluate the regular expression.
+
+    Note that ``match`` and ``search`` just return ``True`` and ``False``
+    at the moment. Make them return a ``MatchObject`` or ``None`` if it
+    becomes necessary.
+    """
+
+    def __init__(self, precondition, *patterns):
+        self.patterns = [re.compile(p) for p in patterns]
+        self.pre = precondition
+        self.pattern = "\n                            ".join(("MERGED:",) + patterns)
+
+    def search(self, text):
+        return self.pre(text) and any(p.search(text) for p in self.patterns)
+
+    def match(self, text):
+        return self.pre(text) and any(p.match(text) for p in self.patterns)
+
+
+_error_matches = [
+    prefilter(
+        lambda x: any(
+            s in x
+            for s in ("Error:", "error", "undefined reference", "multiply defined")
+        ),
+        "([^:]+): error[ \\t]*[0-9]+[ \\t]*:",
+        "([^:]+): (Error:|error|undefined reference|multiply defined)",
+        "([^ :]+) ?: (error|fatal error|catastrophic error)",
+        "([^:]+)\\(([^\\)]+)\\) ?: (error|fatal error|catastrophic error)",
+    ),
+    "^FAILED",
+    "^[Bb]us [Ee]rror",
+    "^[Ss]egmentation [Vv]iolation",
+    "^[Ss]egmentation [Ff]ault",
+    ":.*[Pp]ermission [Dd]enied",
+    "^Error ([0-9]+):",
+    "^Fatal",
+    "^[Ee]rror: ",
+    "^Error ",
+    "[0-9] ERROR: ",
+    '^"[^"]+", line [0-9]+: [^Ww]',
+    "^cc[^C]*CC: ERROR File = ([^,]+), Line = ([0-9]+)",
+    "^ld([^:])*:([ \\t])*ERROR([^:])*:",
+    "^ild:([ \\t])*\\(undefined symbol\\)",
+    "^fatal error C[0-9]+:",
+    ": syntax error ",
+    "^collect2: ld returned 1 exit status",
+    "ld terminated with signal",
+    "Unsatisfied symbol",
+    "^Unresolved:",
+    "Undefined symbol",
+    "^Undefined[ \\t]+first referenced",
+    "^CMake Error.*:",
+    ":[ \\t]cannot find",
+    ":[ \\t]can't find",
+    ": \\*\\*\\* No rule to make target [`'].*\\'.  Stop",
+    ": \\*\\*\\* No targets specified and no makefile found",
+    ": Invalid loader fixup for symbol",
+    ": Invalid fixups exist",
+    ": Can't find library for",
+    ": internal link edit command failed",
+    ": Unrecognized option [`'].*\\'",
+    '", line [0-9]+\\.[0-9]+: [0-9]+-[0-9]+ \\([^WI]\\)',
+    "ld: 0706-006 Cannot find or open library file: -l ",
+    "ild: \\(argument error\\) can't find library argument ::",
+    "^could not be found and will not be loaded.",
+    "s:616 string too big",
+    "make: Fatal error: ",
+    "ld: 0711-993 Error occurred while writing to the output file:",
+    "ld: fatal: ",
+    "final link failed:",
+    "make: \\*\\*\\*.*Error",
+    "make\\[.*\\]: \\*\\*\\*.*Error",
+    "\\*\\*\\* Error code",
+    "nternal error:",
+    "Makefile:[0-9]+: \\*\\*\\* .*  Stop\\.",
+    ": No such file or directory",
+    ": Invalid argument",
+    "^The project cannot be built\\.",
+    "^\\[ERROR\\]",
+    "^Command .* failed with exit code",
+]
+
+_error_exceptions = [
+    "instantiated from ",
+    "candidates are:",
+    ": warning",
+    ": \\(Warning\\)",
+    ": note",
+    "Note:",
+    "makefile:",
+    "Makefile:",
+    ":[ \\t]+Where:",
+    "([^ :]+):([0-9]+): Warning",
+    "------ Build started: .* ------",
+]
+
+#: Regexes to match file/line numbers in error/warning messages
+_warning_matches = [
+    prefilter(
+        lambda x: "warning" in x,
+        "([^ :]+):([0-9]+): warning:",
+        "([^:]+): warning ([0-9]+):",
+        "([^:]+): warning[ \\t]*[0-9]+[ \\t]*:",
+        "([^ :]+) : warning",
+        "([^:]+): warning",
+    ),
+    prefilter(lambda x: "note:" in x, "^([^ :]+):([0-9]+): note:"),
+    prefilter(
+        lambda x: any(s in x for s in ("Warning", "Warnung")),
+        "^(Warning|Warnung) ([0-9]+):",
+        "^(Warning|Warnung)[ :]",
+        "^cxx: Warning:",
+        "([^ :]+):([0-9]+): (Warning|Warnung)",
+        "^CMake Warning.*:",
+    ),
+    "file: .* has no symbols",
+    "^cc[^C]*CC: WARNING File = ([^,]+), Line = ([0-9]+)",
+    "^ld([^:])*:([ \\t])*WARNING([^:])*:",
+    '^"[^"]+", line [0-9]+: [Ww](arning|arnung)',
+    "WARNING: ",
+    '", line [0-9]+\\.[0-9]+: [0-9]+-[0-9]+ \\([WI]\\)',
+    "\\([0-9]*\\): remark #[0-9]*",
+    '".*", line [0-9]+: remark\\([0-9]*\\):',
+    "cc-[0-9]* CC: REMARK File = .*, Line = [0-9]*",
+    "^\\[WARNING\\]",
+]
+
+#: Regexes to match file/line numbers in error/warning messages
+_warning_exceptions = [
+    "/usr/.*/X11/Xlib\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
+    "/usr/.*/X11/Xutil\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
+    "/usr/.*/X11/XResource\\.h:[0-9]+: war.*: ANSI C\\+\\+ forbids declaration",
+    "WARNING 84 :",
+    "WARNING 47 :",
+    "makefile:",
+    "Makefile:",
+    "warning:  Clock skew detected.  Your build may be incomplete.",
+    "/usr/openwin/include/GL/[^:]+:",
+    "bind_at_load",
+    "XrmQGetResource",
+    "IceFlush",
+    "warning LNK4089: all references to [^ \\t]+ discarded by .OPT:REF",
+    "ld32: WARNING 85: definition of dataKey in",
+    'cc: warning 422: Unknown option "\\+b',
+    "_with_warning_C",
+]
+
+#: Regexes to match file/line numbers in error/warning messages
+_file_line_matches = [
+    "^Warning W[0-9]+ ([a-zA-Z.\\:/0-9_+ ~-]+) ([0-9]+):",
+    "^([a-zA-Z./0-9_+ ~-]+):([0-9]+):",
+    "^([a-zA-Z.\\:/0-9_+ ~-]+)\\(([0-9]+)\\)",
+    "^[0-9]+>([a-zA-Z.\\:/0-9_+ ~-]+)\\(([0-9]+)\\)",
+    "^([a-zA-Z./0-9_+ ~-]+)\\(([0-9]+)\\)",
+    '"([a-zA-Z./0-9_+ ~-]+)", line ([0-9]+)',
+    "File = ([a-zA-Z./0-9_+ ~-]+), Line = ([0-9]+)",
+]
+
+
+class LogEvent(object):
+    """Class representing interesting events (e.g., errors) in a build log."""
+
+    def __init__(
+        self,
+        text,
+        line_no,
+        source_file=None,
+        source_line_no=None,
+        pre_context=None,
+        post_context=None,
+    ):
+        self.text = text
+        self.line_no = line_no
+        self.source_file = (source_file,)
+        self.source_line_no = (source_line_no,)
+        self.pre_context = pre_context if pre_context is not None else []
+        self.post_context = post_context if post_context is not None else []
+        self.repeat_count = 0
+
+    @property
+    def start(self):
+        """First line in the log with text for the event or its context."""
+        return self.line_no - len(self.pre_context)
+
+    @property
+    def end(self):
+        """Last line in the log with text for event or its context."""
+        return self.line_no + len(self.post_context) + 1
+
+    def __getitem__(self, line_no):
+        """Index event text and context by actual line number in file."""
+        if line_no == self.line_no:
+            return self.text
+        elif line_no < self.line_no:
+            return self.pre_context[line_no - self.line_no]
+        elif line_no > self.line_no:
+            return self.post_context[line_no - self.line_no - 1]
+
+    def __str__(self):
+        """Returns event lines and context."""
+        out = StringIO()
+        for i in range(self.start, self.end):
+            if i == self.line_no:
+                out.write("  >> %-6d%s" % (i, self[i]))
+            else:
+                out.write("     %-6d%s" % (i, self[i]))
+        return out.getvalue()
+
+
+class BuildError(LogEvent):
+    """LogEvent subclass for build errors."""
+
+
+class BuildWarning(LogEvent):
+    """LogEvent subclass for build warnings."""
+
+
+def chunks(l, n):
+    """Divide l into n approximately-even chunks."""
+    chunksize = int(math.ceil(len(l) / n))
+    return [l[i : i + chunksize] for i in range(0, len(l), chunksize)]
+
+
+@contextmanager
+def _time(times, i):
+    start = time.time()
+    yield
+    end = time.time()
+    times[i] += end - start
+
+
+def _match(matches, exceptions, line):
+    """True if line matches a regex in matches and none in exceptions."""
+    return any(m.search(line) for m in matches) and not any(
+        e.search(line) for e in exceptions
+    )
+
+
+def _profile_match(matches, exceptions, line, match_times, exc_times):
+    """Profiled version of match().
+
+    Timing is expensive so we have two whole functions.  This is much
+    longer because we have to break up the ``any()`` calls.
+
+    """
+    for i, m in enumerate(matches):
+        with _time(match_times, i):
+            if m.search(line):
+                break
+    else:
+        return False
+
+    for i, m in enumerate(exceptions):
+        with _time(exc_times, i):
+            if m.search(line):
+                return False
+    else:
+        return True
+
+
+def _parse(lines, offset, profile):
+    def compile(regex_array):
+        return [
+            regex if isinstance(regex, prefilter) else re.compile(regex)
+            for regex in regex_array
+        ]
+
+    error_matches = compile(_error_matches)
+    error_exceptions = compile(_error_exceptions)
+    warning_matches = compile(_warning_matches)
+    warning_exceptions = compile(_warning_exceptions)
+    file_line_matches = compile(_file_line_matches)
+
+    matcher, args = _match, []
+    timings = []
+    if profile:
+        matcher = _profile_match
+        timings = [
+            [0.0] * len(error_matches),
+            [0.0] * len(error_exceptions),
+            [0.0] * len(warning_matches),
+            [0.0] * len(warning_exceptions),
+        ]
+
+    errors = []
+    warnings = []
+    for i, line in enumerate(lines):
+        # use CTest's regular expressions to scrape the log for events
+        if matcher(error_matches, error_exceptions, line, *timings[:2]):
+            event = BuildError(line.strip(), offset + i + 1)
+            errors.append(event)
+        elif matcher(warning_matches, warning_exceptions, line, *timings[2:]):
+            event = BuildWarning(line.strip(), offset + i + 1)
+            warnings.append(event)
+        else:
+            continue
+
+        # get file/line number for each event, if possible
+        for flm in file_line_matches:
+            match = flm.search(line)
+            if match:
+                event.source_file, event.source_line_no = match.groups()
+
+    return errors, warnings, timings
+
+
+def _parse_unpack(args):
+    return _parse(*args)
+
+
+class CTestLogParser(object):
+    """Log file parser that extracts errors and warnings."""
+
+    def __init__(self, profile=False):
+        # whether to record timing information
+        self.timings = []
+        self.profile = profile
+
+    def print_timings(self):
+        """Print out profile of time spent in different regular expressions."""
+
+        def stringify(elt):
+            return elt if isinstance(elt, str) else elt.pattern
+
+        index = 0
+        for name, arr in [
+            ("error_matches", _error_matches),
+            ("error_exceptions", _error_exceptions),
+            ("warning_matches", _warning_matches),
+            ("warning_exceptions", _warning_exceptions),
+        ]:
+
+            print()
+            print(name)
+            for i, elt in enumerate(arr):
+                print(
+                    "%16.2f        %s" % (self.timings[index][i] * 1e6, stringify(elt))
+                )
+            index += 1
+
+    def parse(self, stream, context=6, jobs=None):
+        """Parse a log text by searching each line for errors and warnings.
+
+        This is modified from the spack version to get as input a string.
+        Args:
+            stream (str or file-like): filename or stream to read from
+            context (int): lines of context to extract around each log event
+
+        Returns:
+            (tuple): two lists containing ``BuildError`` and
+                ``BuildWarning`` objects.
+        """
+        if not stream:
+            return [], []
+
+        lines = [line for line in stream.split("\n")]
+
+        if jobs is None:
+            jobs = multiprocessing.cpu_count()
+
+        # single-thread small logs
+        if len(lines) < 10 * jobs:
+            errors, warnings, self.timings = _parse(lines, 0, self.profile)
+
+        else:
+            # Build arguments for parallel jobs
+            args = []
+            offset = 0
+            for chunk in chunks(lines, jobs):
+                args.append((chunk, offset, self.profile))
+                offset += len(chunk)
+
+            # create a pool and farm out the matching job
+            pool = multiprocessing.Pool(jobs)
+            try:
+                # this is a workaround for a Python bug in Pool with ctrl-C
+                results = pool.map_async(_parse_unpack, args, 1).get(9999999)
+                errors, warnings, timings = zip(*results)
+            finally:
+                pool.terminate()
+
+            # merge results
+            errors = sum(errors, [])
+            warnings = sum(warnings, [])
+
+            if self.profile:
+                self.timings = [[sum(i) for i in zip(*t)] for t in zip(*timings)]
+
+        # add log context to all events
+        for event in errors + warnings:
+            i = event.line_no - 1
+            event.pre_context = [l.rstrip() for l in lines[i - context : i]]
+            event.post_context = [l.rstrip() for l in lines[i + 1 : i + context + 1]]
+
+        return errors, warnings

--- a/spackmon/apps/main/templates/builds/detail.html
+++ b/spackmon/apps/main/templates/builds/detail.html
@@ -4,10 +4,23 @@
 {% load static %}
 {% block page_title %}Build > {{ build }}{% endblock %}
 {% block css %}
+<style>
+pre {
+  max-height: none !important; /*workaround for Prism scrollbars*/
+}
+</style>
 {% endblock %}
 {% block content %}
 
 <div class="row" style="padding-bottom:25px">
+    <div class="col-md-2">
+        <h4></h4>
+        <ul class="list-group">
+        {% if build.build_warnings_parsed > 0 %}<a href="#build-warnings"><li class="list-group-item">Warnings</li></a>{% endif %}
+        {% if build.build_errors_parsed > 0 %}<a href="#build-errors"><li class="list-group-item">Errors</li></a>{% endif %}
+        {% if build.buildphase_set.count > 0 %}<a href="#full-logs"><li class="list-group-item">Full Logs</li></a>{% endif %}
+        </ul>
+    </div>
    <div class="col-md-4">
       <h4>Summary</h4>
 
@@ -38,11 +51,69 @@
       <b>Kernel Version: </b>{{ build.build_environment.kernel_version }}
       <br>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-2">
         {% include "builds/phase_table.html" %}
     </div>
 </div>
 
+
+{% if build.build_warnings_parsed > 0 %}<div class="row">
+    <div class="col-md-12">
+      <h4 id="build-warnings">Build Warnings</h4>
+
+<div id="accordion">
+  {% for warning in build.build_warnings %}<div class="card" style="padding:0px 5px;">
+    <div class="card-header" id="heading-warning-{{ warning.id }}">
+      <h5 class="mb-0">
+        <a data-toggle="collapse" data-target="#collapse-warning-{{ warning.id }}" aria-expanded="true" aria-controls="collapseOne">
+          <span class="alert alert-warning" style="color:black; width:100%; display:block">{{ warning.text }}</span>
+        </a>
+      </h5>
+    </div>
+
+    <div id="collapse-warning-{{ warning.id }}" class="collapse show" aria-labelledby="heading-warning-{{ warning.id }}" data-parent="#accordion">
+      <div class="card-body">
+      <pre data-line=5 class="line-numbers"><code class="language-console">
+         {{ warning.pre_context }}
+         {{ warning.text }}
+         {{ warning.post_context }}      
+      </code></pre>
+      </div>
+    </div>
+  </div>{% endfor %}
+</div>
+    </div>
+</div>{% endif %}
+{% if build.build_errors_parsed > 0 %}<div class="row">
+    <div class="col-md-12">
+      <h4 id="build-errors">Build Errors</h4>
+
+<div id="accordion">
+  {% for error in build.build_errors %}<div class="card" style="padding:0px 5px;">
+    <div class="card-header" id="heading-error-{{ error.id }}">
+      <h5 class="mb-0">
+        <a data-toggle="collapse" data-target="#collapse-error-{{ error.id }}" aria-expanded="true" aria-controls="collapseOne">
+          <span class="alert alert-danger" style="width:100%; display:block">{{ error.text }}</span>
+        </a>
+      </h5>
+    </div>
+
+    <div id="collapse-error-{{ error.id }}" class="collapse show" aria-labelledby="heading-error-{{ error.id }}" data-parent="#accordion">
+      <div class="card-body">
+      <pre data-line=5 class="line-numbers"><code class="language-console">
+         {{ error.pre_context }}
+         {{ error.text }}
+         {{ error.post_context }}      
+      </code></pre>
+      </div>
+    </div>
+  </div>{% endfor %}
+</div>
+    </div>
+</div>{% endif %}
+
+{% if build.buildphase_set.count > 0 %}
+<h4 id="full-logs">Full Logs</h4>
 {% for phase in build.buildphase_set.all %}
 <div class="title-divider" id="phase-{{ phase.name }}">
     {{ phase.name }}
@@ -50,11 +121,13 @@
 {% if phase.output %}<b>Output: </b>
       <br>
       <pre>{{ phase.output }}</pre>{% else %}<p class="alert alert-secondary">This phase does not have any output</p>{% endif %}
-{% endfor %}
+{% endfor %}{% endif %}
 {% endblock %}
 {% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/prism.min.js"></script>
 <script>
 $(document).ready(function() {
+   $('.collapse').collapse()
 });
 </script>
 {% endblock %}

--- a/spackmon/apps/main/templates/specs/detail.html
+++ b/spackmon/apps/main/templates/specs/detail.html
@@ -17,7 +17,62 @@
     </div>
    <div class="col-md-4">
       <h4></h4>
-    <a href="{% url 'main:build_detail' spec.build_set.first.id %}"><span class="badge badge-primary">build details</span></a>
+    {% if spec.build_set.count > 0 %}<a href="{% url 'main:build_detail' spec.build_set.first.id %}"><span class="badge badge-primary">build details</span></a>{% else %}<p style="padding:10px; radius:3px" class="alert-info">This spec build was not attempted.</p>{% endif %}
+      <div class="row">
+          <div class="col-md-6">
+          {% if spec.dependencies.count > 0 %}
+          <table><tbody class="table">
+          <td>
+            <table class="dart">
+              <tbody><tr class="table-heading">
+                <th colspan="2">Dependencies</th>
+              </tr>
+              <tr class="table-heading">
+                <th>Name</th>
+                <th>Status</th>
+              </tr>
+              {% for dep in spec.dependencies.all %}<tr class="tr-odd">
+                <td>
+                    <b><a href="{% url 'main:spec_detail' dep.spec.id %}">{{ dep.spec.name }}</a></b>
+                </td>
+                <td class="normal" align="right">{% if dep.spec.build_set.count == 0 %}<span title="NOT RUN means there were no build phases sent for this spec." class="badge badge-secondary">NOT RUN</span>{% else %}
+                  <b>{% for phase in dep.spec.build_set.all %}<span class="badge badge-{% if phase.status == "CANCELLED" %}warning{% elif phase.status == "SUCCESS" %}success{% elif phase.status == "FAILED" %}error{% else %}info{% endif %}">{{ phase.status }}</span>{% endfor %}
+                  </b>{% endif %}
+                </td>
+              </tr>{% endfor %}
+            </tbody></table>
+      </tbody></table>
+      <br>{% endif %}
+      
+          </div>
+          <div class="col-md-6">
+          {% with deps=spec.get_needed_by %}
+          {% if deps|length > 0 %}
+          <table><tbody class="table">
+          <td>
+            <table class="dart">
+              <tbody><tr class="table-heading">
+                <th colspan="2">Needed By</th>
+              </tr>
+              <tr class="table-heading">
+                <th>Name</th>
+                <th>Status</th>
+              </tr>
+              {% for dep in deps %}<tr class="tr-odd">
+                <td>
+                    <b><a href="{% url 'main:spec_detail' dep.id %}">{{ dep.name }}</a></b>
+                </td>
+                <td class="normal" align="right">{% if dep.build_set.count == 0 %}<span title="NOT RUN means there were no build phases sent for this spec." class="badge badge-secondary">NOT RUN</span>{% else %}
+                  <b>{% for phase in dep.build_set.all %}<span class="badge badge-{% if phase.status == "CANCELLED" %}warning{% elif phase.status == "SUCCESS" %}success{% elif phase.status == "FAILED" %}danger{% else %}info{% endif %}">{{ phase.status }}</span>{% endfor %}
+                  </b>{% endif %}
+                </td>
+              </tr>{% endfor %}
+            </tbody></table>
+      </tbody></table>
+      <br>{% endif %}{% endwith %}
+          </div>
+      </div>
+
    </div>
 </div>
 {% endblock %}

--- a/spackmon/apps/main/views.py
+++ b/spackmon/apps/main/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import HttpResponseForbidden, JsonResponse
 from spackmon.apps.main.models import Spec, Build
+from spackmon.apps.main.logparser import parse_build_logs
 import os
 
 from ratelimit.decorators import ratelimit
@@ -31,6 +32,10 @@ def index(request):
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def build_detail(request, bid):
     build = get_object_or_404(Build, pk=bid)
+
+    # Generate BuildWarnings and BuildErrors if don't exist
+    if build.logs_parsed == 0:
+        parse_build_logs(build)
     return render(request, "builds/detail.html", {"build": build})
 
 

--- a/spackmon/apps/users/models.py
+++ b/spackmon/apps/users/models.py
@@ -43,13 +43,13 @@ class CustomUserManager(BaseUserManager):
         return self._create_user(username, email, password, True, True, **extra_fields)
 
     def add_superuser(self, user):
-        """ Intended for existing user"""
+        """Intended for existing user"""
         user.is_superuser = True
         user.save(using=self._db)
         return user
 
     def add_staff(self, user):
-        """ Intended for existing user"""
+        """Intended for existing user"""
         user.is_staff = True
         user.save(using=self._db)
         return user
@@ -74,7 +74,7 @@ class User(AbstractUser):
         return str(Token.objects.get(user=self))
 
     def get_credentials(self, provider):
-        """ return one or more credentials, or None"""
+        """return one or more credentials, or None"""
         if self.is_anonymous is False:
             try:
                 # Case 1: one credential


### PR DESCRIPTION
This will add BuildWarning and BuildError to be parsed from a BuildPhase.output and buildPhase.error, and the results are generated on demand and stored in the database to parse into the build details view. Since we could not easily see the dependencies or parents of a particular spec these are also added to the main page for the spec details.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>