### PR TITLE
adding support for build tags

### DIFF
--- a/spackmon/apps/api/views/builds.py
+++ b/spackmon/apps/api/views/builds.py
@@ -127,6 +127,7 @@ class NewBuild(APIView):
 
         # Get the complete build environment
         data = json.loads(request.body)
+        tag = data.get("tag")
         build_environment = get_build_environment(data)
         if not build_environment:
             return Response(
@@ -134,14 +135,14 @@ class NewBuild(APIView):
             )
 
         # Create the new build
-        result = get_build(**build_environment)
+        result = get_build(**build_environment, tag=tag)
 
         # If a spec is included in the build, the requester is okay to create
         # it given that it does not exist.
         if "spec" in data and "spack_version" in data:
             spack_version = data.get("spack_version")
             result = import_configuration(data["spec"], data["spack_version"])
-            result = get_build(**build_environment)
+            result = get_build(**build_environment, tag=tag)
 
         # Prepare data with
         return Response(status=result["code"], data=result)

--- a/spackmon/apps/main/models.py
+++ b/spackmon/apps/main/models.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField as DjangoJSONField
 from django.db.models import Field, Count
+from taggit.managers import TaggableManager
 from itertools import chain
 
 from .utils import BUILD_STATUS, PHASE_STATUS, FILE_CATEGORIES
@@ -205,6 +206,9 @@ class Build(BaseModel):
     spec = models.ForeignKey(
         "main.Spec", null=False, blank=False, on_delete=models.CASCADE
     )
+
+    # Tags for the build to identify the experiment
+    tags = TaggableManager()
 
     # States: succeed, fail, fail because dependency failed (cancelled), not run
     status = models.CharField(

--- a/spackmon/apps/main/tasks.py
+++ b/spackmon/apps/main/tasks.py
@@ -45,7 +45,14 @@ def update_build_phase(build, phase_name, status, output, **kwargs):
 
 
 def get_build(
-    full_hash, spack_version, hostname, kernel_version, host_os, host_target, platform
+    full_hash,
+    spack_version,
+    hostname,
+    kernel_version,
+    host_os,
+    host_target,
+    platform,
+    tag=None,
 ):
     """A shared function to first retrieve a spec, then the environment, then the build.
     This could be made much more efficient if we create a build id to return to the client
@@ -73,6 +80,11 @@ def get_build(
     build, build_created = Build.objects.get_or_create(
         spec=spec, build_environment=build_environment
     )
+
+    # Update the tags
+    if tag:
+        build.tags.add(tag)
+        build.save()
 
     return {
         "message": "Build get or create was successful.",

--- a/spackmon/apps/main/templates/main/index.html
+++ b/spackmon/apps/main/templates/main/index.html
@@ -26,7 +26,7 @@ code {
 <div class="buildgroup">
 <h3 class="buildgroupname">
   <a href="#" class="grouptrigger">
-    Spack Monitor Builds
+    Spack Monitor Builds{% if tag %}: {{ tag }}{% endif %}
   </a>
   <span class="buildnums" align="right">{{ builds.count }}</span>
 </h3>
@@ -61,7 +61,7 @@ code {
       </th>
 
       <th class="column-header">
-        Analysis?
+        Tags
         <span class="glyphicon glyphicon-chevron-down"></span>
       </th>
       <th class="column-header">
@@ -97,7 +97,7 @@ code {
              {{ build.phase_success_count }}
        </td>
        <td class="error" align="center">{{ build.phase_error_count }}</td>
-       <td align="center">{% if build.has_analysis %}✔️{% endif %}</td>
+       <td align="center">{% for tag in build.tags.all %}<a style="color:white" href="{% url 'main:builds_by_tag' tag %}"><span class="badge badge-info">{{ tag }}</span></a>{% endfor %}</td>
        <td align="center">{{ build.installfile_set.count }}</td>
        <td align="center">{{ build.envars.count }}</td>
        <td align="center">{{ build.modify_date }}</td>

--- a/spackmon/apps/main/urls.py
+++ b/spackmon/apps/main/urls.py
@@ -9,6 +9,7 @@ from . import views
 urlpatterns = [
     path("", views.index, name="dashboard"),
     path("builds/<int:bid>/", views.build_detail, name="build_detail"),
+    path("builds/tag/<str:tag>/", views.builds_by_tag, name="builds_by_tag"),
     path("specs/diff/<int:spec1>/<int:spec2>/", views.spec_diff, name="spec-diff"),
     path("specs/diff/", views.spec_diff, name="spec-diff"),
     path("specs/detail/<int:specid>", views.spec_detail, name="spec_detail"),

--- a/spackmon/apps/main/views.py
+++ b/spackmon/apps/main/views.py
@@ -30,6 +30,12 @@ def index(request):
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def builds_by_tag(request, tag):
+    builds = Build.objects.filter(tags__name=tag)
+    return render(request, "main/index.html", {"builds": builds, "tag": tag})
+
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def build_detail(request, bid):
     build = get_object_or_404(Build, pk=bid)
 

--- a/spackmon/settings.py
+++ b/spackmon/settings.py
@@ -131,6 +131,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "crispy_forms",
     "social_django",
+    "taggit",
     "rest_framework",
     "rest_framework.authtoken",
 ]
@@ -301,6 +302,9 @@ CACHE_MIDDLEWARE_SECONDS = 86400  # one day
 
 # POSTs to API typically have a limit of 2.5MB, disable limit
 DATA_UPLOAD_MAX_MEMORY_SIZE = None
+
+# Tags should not be case sensitive
+TAGGIT_CASE_INSENSITIVE = True
 
 # Add cache middleware
 for entry in [


### PR DESCRIPTION
This will allow us to tag an experiment during a spack install. And then we can browse by tags, e.g.:

![image](https://user-images.githubusercontent.com/814322/118569501-4bef7280-b737-11eb-83c7-3aee10d7156c.png)


Signed-off-by: vsoch <vsoch@users.noreply.github.com>