### PR TITLE
Start of work to refactor main table to use server side rendering

### DIFF
--- a/nginx/uwsgi.ini
+++ b/nginx/uwsgi.ini
@@ -13,3 +13,4 @@ wsgi-file = spackmon/wsgi.py
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+buffer-size=32768

--- a/spackmon/apps/api/urls.py
+++ b/spackmon/apps/api/urls.py
@@ -47,6 +47,11 @@ urlpatterns = [
         api_views.UpdateBuildMetadata.as_view(),
         name="update_build_metadata",
     ),
+    path(
+        "tables/build/",
+        api_views.BuildsTable.as_view(),
+        name="builds_table",
+    ),
 ]
 
 app_name = "api"

--- a/spackmon/apps/api/views/__init__.py
+++ b/spackmon/apps/api/views/__init__.py
@@ -3,3 +3,4 @@ from .base import ServiceInfo
 from .specs import NewSpec
 from .builds import UpdateBuildStatus, UpdatePhaseStatus, NewBuild
 from .analyze import UpdateBuildMetadata
+from .tables import BuildsTable

--- a/spackmon/apps/api/views/tables.py
+++ b/spackmon/apps/api/views/tables.py
@@ -1,0 +1,163 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from django.conf import settings
+from django.urls import reverse
+from django.db.models import Count, Case, When, IntegerField, Q
+
+from ratelimit.mixins import RatelimitMixin
+
+from spackmon.settings import cfg
+from spackmon.version import __version__
+from spackmon.apps.main.models import Build
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+def filter_buildphase_set(queryset, order_by, status):
+    """Given a queryset, order by a particular status and sort."""
+    prefix = ""
+    if "desc" in order_by:
+        prefix = "-"
+    queryset = queryset.annotate(
+        count_buildphase=Count(
+            Case(
+                When(buildphase__status=status, then=1),
+                output_field=IntegerField(),
+            )
+        )
+    ).order_by("%scount_buildphase" % prefix)
+    return queryset
+
+
+def filter_buildfield(queryset, order_by, field):
+    """Given a queryset, order by a particular field and sort."""
+    prefix = ""
+    if "desc" in order_by:
+        prefix = "-"
+    return queryset.annotate(count_custom=Count(field)).order_by(
+        "%scount_custom" % prefix
+    )
+
+
+class BuildsTable(RatelimitMixin, APIView):
+    """server side render main index table"""
+
+    ratelimit_key = "ip"
+    ratelimit_rate = settings.VIEW_RATE_LIMIT
+    ratelimit_block = settings.VIEW_RATE_LIMIT_BLOCK
+    ratelimit_method = "GET"
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, year=None):
+        print("GET BuildsTable")
+
+        # Start and length to return
+        start = int(request.GET["start"])
+        length = int(request.GET["length"])
+        draw = int(request.GET["draw"])
+        query = request.GET.get("search[value]", "")
+        queryset = Build.objects.all()
+
+        # First do the search to reduce the size of the set
+        if query:
+            queryset = queryset.filter(
+                Q(spec__name__icontains=query)
+                | Q(spec__version__icontains=query)
+                | Q(spec__compiler__name__icontains=query)
+                | Q(spec__compiler__version__icontains=query)
+                | Q(spec__full_hash__icontains=query)
+                | Q(build_environment__platform__icontains=query)
+                | Q(build_environment__host_os__icontains=query)
+                | Q(build_environment__host_target__icontains=query)
+                | Q(status__icontains=query)
+                | Q(tags__name__icontains=query)
+                | Q(modify_date__icontains=query)
+            )
+
+        # Order column and direction
+        order = request.GET["order[0][column]"]
+        direction = request.GET["order[0][dir]"]  # asc or desc
+        order_lookup = {
+            "0asc": "spec__name",
+            "0desc": "-spec__name",
+            "1asc": "build_environment__platform",
+            "1desc": "-build_environment__platform",
+            "2asc": "spec__compiler__name",
+            "2desc": "-spec__compiler__name",
+            "3asc": "status",
+            "3desc": "-status",
+            "6asc": "tags__name",
+            "6desc": "-tags__name",
+            "7asc": "modify_date",
+            "7desc": "-modify_date",
+        }
+
+        # Empty datatable
+        data = {"draw": draw, "recordsTotal": 0, "recordsFiltered": 0, "data": []}
+        taglist = []
+        count = 0
+
+        order_by = "%s%s" % (order, direction)
+        if order_by in order_lookup:
+            print(f"Ordering by {order_by}")
+            queryset = queryset.order_by(order_lookup[order_by])
+            count = queryset.count()
+
+        # Custom orderings
+        elif order_by.startswith("4"):
+            queryset = filter_buildphase_set(queryset, order_by, "SUCCESS")
+            count = queryset.count()
+
+        elif order_by.startswith("5"):
+            queryset = filter_buildphase_set(queryset, order_by, "ERROR")
+            count = queryset.count()
+
+        if start > count:
+            start = 0
+        end = start + length - 1
+
+        # If we've gone too far
+        if end > count:
+            end = count - 1
+
+        queryset = queryset[start : end + 1]
+        data["recordsTotal"] = count
+        data["recordsFiltered"] = count
+
+        for build in queryset:
+
+            tags = ""
+            for tag in build.tags.all():
+                tags += (
+                    (
+                        '<a style="color:white" href="%s"><span class="badge badge-info">'
+                        % reverse("main:builds_by_tag", args=[tag.name])
+                    )
+                    + tag.name
+                    + "</span></a>"
+                )
+
+            data["data"].append(
+                [
+                    '<a href="%s">%s</a><a href="%s"><span style="float:right" class="badge badge-primary">build details</span></a>'
+                    % (
+                        reverse("main:spec_detail", args=[build.spec.id]),
+                        build.spec.pretty_print(),
+                        reverse("main:build_detail", args=[build.id]),
+                    ),
+                    '<div style="float: left; margin: 0px 4px;">%s</div>'
+                    % build.build_environment.arch,
+                    '<div style="float: left; margin: 0px 4px;">%s</div>'
+                    % build.spec.compiler,
+                    build.status,
+                    build.phase_success_count,
+                    build.phase_error_count,
+                    tags,
+                    build.modify_date,
+                ]
+            )
+        return Response(status=200, data=data)

--- a/spackmon/apps/main/templates/main/index.html
+++ b/spackmon/apps/main/templates/main/index.html
@@ -22,13 +22,13 @@ code {
 {% endblock %}
 {% block content %}
 
-<!-- TODO when this table gets large, do server side rendering -->
 <div class="buildgroup">
 <h3 class="buildgroupname">
   <a href="#" class="grouptrigger">
     Spack Monitor Builds{% if tag %}: {{ tag }}{% endif %}
   </a>
-  <span class="buildnums" align="right">{{ builds.count }}</span>
+  <span class="buildnums" align="right">{{ builds.count }}</span><span style="padding-left:50px">
+{% for tag in tags %}{% if tag %}<a style="color:white; padding-left:3px" href="{% url 'main:builds_by_tag' tag %}"><span class="badge badge-primary">{{ tag }}</span></a>{% endif %}{% endfor %}</span>
 </h3>
 <table class="tabb compact" id="builds_table" width="100%" cellspacing="0" cellpadding="4" border="0">
   <thead>
@@ -59,17 +59,8 @@ code {
         Error
         <span class="glyphicon glyphicon-chevron-down"></span>
       </th>
-
       <th class="column-header">
         Tags
-        <span class="glyphicon glyphicon-chevron-down"></span>
-      </th>
-      <th class="column-header">
-        Install Files
-        <span class="glyphicon glyphicon-chevron-down"></span>
-      </th>
-      <th class="column-header">
-        Envars
         <span class="glyphicon glyphicon-chevron-down"></span>
       </th>
       <th class="column-header">
@@ -78,31 +69,7 @@ code {
       </th>
    </tr>
   </thead>
-
-  <tbody>{% for build in builds %}
-    <tr class="odd" valign="middle">
-       <td class="paddt" style="" align="left">
-           <a href="{% url 'main:spec_detail' build.spec.id %}">{{ build.spec.pretty_print }}</a> <a href="{% url 'main:build_detail' build.id %}"><span style="float:right" class="badge badge-primary">build details</span></a>
-       </td>
-       <td style="" align="left">
-           <div style="float: left; margin: 0px 4px;">{{ build.build_environment.arch }}</div>
-       </td>
-       <td style="" align="left">
-           <div style="float: left; margin: 0px 4px;">{{ build.spec.compiler }}</div>
-       </td>
-       <td class="{% if build.status == 'SUCCESS' %}normal{% endif %}{% if build.status == 'ERRPR' %}error{% endif %}{% if build.status == 'CANCELLED' %}warning{% endif %}" style="" align="center">
-             {{ build.status }}
-       </td>
-       <td class="normal" style="" align="center">
-             {{ build.phase_success_count }}
-       </td>
-       <td class="error" align="center">{{ build.phase_error_count }}</td>
-       <td align="center">{% for tag in build.tags.all %}<a style="color:white" href="{% url 'main:builds_by_tag' tag %}"><span class="badge badge-info">{{ tag }}</span></a>{% endfor %}</td>
-       <td align="center">{{ build.installfile_set.count }}</td>
-       <td align="center">{{ build.envars.count }}</td>
-       <td align="center">{{ build.modify_date }}</td>
-      </tr>{% endfor %}
-  </tbody>
+  <tbody></tbody>
 </table>
 </div>
 </div>
@@ -111,8 +78,28 @@ code {
 {% block scripts %}
 <script>
 $(document).ready(function(){
-    $("#builds_table").DataTable({"order": [[ 3, "desc" ]]});
-    $("#builds_table").prepend('<thead><tr class="table-heading1"><td colspan="3" rowspan="1" class="nob"></td><td colspan="1" rowspan="1" class="center-text">Build</td><td colspan="2" rowspan="1" class="center-text">Phases</td><td colspan="3" rowspan="1" class="center-text">Analyze</td><td class="nob" align="right"></td></tr></thead>')
+    $("#builds_table").dataTable({"order": [[ 3, "desc" ]], "pageLength": 10, "processing": true, "serverSide": true, "ajax": "{% url 'api:builds_table' %}", "lengthMenu": [[10,15,20,25], [10,15,20,25]],
+    columnDefs: [ {
+    targets: 3,
+    createdCell: function (td, cellData, rowData, row, col) {
+        console.log(row);
+        if (( rowData[3] === 'SUCCESS' ) && (row % 2 != 0)) {
+            $(td).css('background-color', '#bfefbf');
+        } else if ((rowData[3] === 'SUCCESS') && (row % 2 == 0)) {
+            $(td).css('background-color', '#b4dcb4');
+        } else if ((rowData[3] === 'FAILED') && (row % 2 != 0)) {        
+            $(td).css('background-color', '#de6868');  
+        } else if ((rowData[3] === 'FAILED') && (row % 2 == 0)) {        
+            $(td).css('background-color', '#d95454');
+        } else if ((rowData[3] === 'CANCELLED') && (row % 2 != 0)) {
+            $(td).css('background-color', "#fd9e40");
+        } else if ((rowData[3] === 'CANCELLED') && (row % 2 == 0)) {
+            $(td).css('background-color', "#f39130");
+        }
+    }
+  }] 
+  });
+    $("#builds_table").prepend('<thead><tr class="table-heading1"><td colspan="3" rowspan="1" class="nob"></td><td colspan="1" rowspan="1" class="center-text">Build</td><td colspan="2" rowspan="1" class="center-text">Phases</td><td colspan="3" rowspan="1" class="center-text"></td><td class="nob" align="right"></td></tr></thead>')
 });
 </script>
 {% endblock %}

--- a/spackmon/apps/main/views.py
+++ b/spackmon/apps/main/views.py
@@ -26,13 +26,19 @@ import json
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def index(request):
     builds = Build.objects.all()
-    return render(request, "main/index.html", {"builds": builds})
+    tags = builds.values_list("tags__name", flat=True).distinct()
+    return render(request, "main/index.html", {"builds": builds, "tags": tags})
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def builds_by_tag(request, tag):
     builds = Build.objects.filter(tags__name=tag)
-    return render(request, "main/index.html", {"builds": builds, "tag": tag})
+
+    # Present all tags for browsing
+    tags = Build.objects.all().values_list("tags__name", flat=True).distinct()
+    return render(
+        request, "main/index.html", {"builds": builds, "tag": tag, "tags": tags}
+    )
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)


### PR DESCRIPTION
As the front page scales, we need a view that can handle this. For the time being, server side pagination is a reasonable approach, meaning we only render what the user asks to see on demand (some 10 records). Instead of trying to print all rows in Build in the browser, this server side approach adds an endpoint to expect a query from this view, and then parse the user preferences (e.g., sorting, search, etc.). This might need to change if this service ever gets much bigger, but for now this should work.

All that is left to do is a little work to make it pretty/colored again. We probably want to also re-discuss what fields to show (some aren't as meaningful). Here is the shot now, and note that I haven't added coloring back to columns yet (e.g., SUCCESS should be green).

![image](https://user-images.githubusercontent.com/814322/118754570-969ae880-b824-11eb-8e6c-78d393e10328.png)

I also added a clean list of all tags at the top so the table view can quickly be re-rendered to show a particular tag.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>